### PR TITLE
Convenience method for paths

### DIFF
--- a/src/AbstractInstaller.php
+++ b/src/AbstractInstaller.php
@@ -72,4 +72,9 @@ abstract class AbstractInstaller {
         else
             $logger->log(LogLevel::NOTICE, 'Could not delete file "'.$file.'"');
     }
+    
+    protected static function path($segment)
+    {
+        return join(DIRECTORY_SEPARATOR, func_get_args());
+    }
 }

--- a/src/Installers/DrupalInstaller.php
+++ b/src/Installers/DrupalInstaller.php
@@ -10,23 +10,23 @@ use \Exception;
 
 class DrupalInstaller extends AbstractInstaller {
     static public function createConfiguration(array $data, $directory, ConsoleLogger $logger) {
-        if (!file_exists($directory.DIRECTORY_SEPARATOR.'sites'.DIRECTORY_SEPARATOR.'default'.DIRECTORY_SEPARATOR.'default.settings.php'))
+        if (!file_exists(self::path($directory, 'sites', 'default', 'default.settings.php')))
             throw new Exception('Inconsistency in drupal directory "'.$directory.'". File sites/default/default.settings.php does not exist!');
-        if (!copy($directory.DIRECTORY_SEPARATOR.'sites'.DIRECTORY_SEPARATOR.'default'.DIRECTORY_SEPARATOR.'default.settings.php', $directory.DIRECTORY_SEPARATOR.'sites'.DIRECTORY_SEPARATOR.'default'.DIRECTORY_SEPARATOR.'settings.php'))
+        if (!copy(self::path($directory, 'sites', 'default', 'default.settings.php'), self::path($directory, 'sites', 'default', 'settings.php')))
             throw new Exception('Could not copy sample configuration to original configuration in directory "'.$directory.'"!');
 
-        if (!chmod($directory.DIRECTORY_SEPARATOR.'sites'.DIRECTORY_SEPARATOR.'default'.DIRECTORY_SEPARATOR.'default.settings.php', 0666))
+        if (!chmod(self::path($directory, 'sites', 'default', 'default.settings.php'), 0666))
             throw new Exception('Could not change permissions of configuration file in directory "'.$directory.'"!');
         $logger->log(LogLevel::INFO, 'Configuration saved');
     }
 
     static public function createFilesDir(array $data, $directory, ConsoleLogger $logger) {
-        if (is_dir($directory.DIRECTORY_SEPARATOR.'sites'.DIRECTORY_SEPARATOR.'default'.DIRECTORY_SEPARATOR.'files') && !fileperms($directory.DIRECTORY_SEPARATOR.'sites'.DIRECTORY_SEPARATOR.'default'.DIRECTORY_SEPARATOR.'files') !== 0755) {
-            if (!chmod($directory.DIRECTORY_SEPARATOR.'sites'.DIRECTORY_SEPARATOR.'default'.DIRECTORY_SEPARATOR.'files', 0755))
+        if (is_dir(self::path($directory, 'sites', 'default', 'files')) && !fileperms(self::path($directory, 'sites', 'default', 'files')) !== 0755) {
+            if (!chmod(self::path($directory, 'sites', 'default', 'files'), 0755))
                 throw new Exception('Could not change permissions of files directory in directory "'.$directory.'"!');
             $logger->log(LogLevel::INFO, 'Files dir exist and is writable');
         } else {
-            if (!mkdir($directory.DIRECTORY_SEPARATOR.'sites'.DIRECTORY_SEPARATOR.'default'.DIRECTORY_SEPARATOR.'files', 0755))
+            if (!mkdir(self::path($directory, 'sites', 'default', 'files'), 0755))
                 throw new Exception('Could not create new files dir with all permissions in directory "'.$directory.'"!');
             $logger->log(LogLevel::INFO, 'Files dir created');
         }

--- a/src/Installers/WordpressInstaller.php
+++ b/src/Installers/WordpressInstaller.php
@@ -11,11 +11,11 @@ use \Exception;
 class WordpressInstaller extends AbstractInstaller {
     static public function createConfiguration(array $data, $directory, ConsoleLogger $logger) {
         if (isset($data['database'])) {
-            if (!file_exists($directory.DIRECTORY_SEPARATOR.'wp-config-sample.php'))
+            if (!file_exists(self::path($directory, 'wp-config-sample.php')))
                 throw new Exception('Inconsistency in wordpress directory "'.$directory.'". File wp-config-sample.php does not exist!');
-            if (!copy($directory.DIRECTORY_SEPARATOR.'wp-config-sample.php', $directory.DIRECTORY_SEPARATOR.'wp-config.php'))
+            if (!copy(self::path($directory, 'wp-config-sample.php'), self::path($directory, 'wp-config.php')))
                 throw new Exception('Could not copy sample configuration to original configuration in directory "'.$directory.'"!');
-            $fp = file_get_contents($directory.DIRECTORY_SEPARATOR.'wp-config.php');
+            $fp = file_get_contents(self::path($directory, 'wp-config.php'));
             $fp = preg_replace(array(
                     '~define\((\'|")DB_NAME(\'|"),\s+(\'|").+(\'|")\)\;~',
                     '~define\((\'|")DB_USER(\'|"),\s+(\'|").+(\'|")\)\;~',
@@ -28,7 +28,7 @@ class WordpressInstaller extends AbstractInstaller {
                     'define("DB_PASSWORD", "'.$data['database']['password'].'");',
                     'define("DB_HOST", "'.$data['database']['host'].'");'
                 ), $fp);
-            file_put_contents($directory.DIRECTORY_SEPARATOR.'wp-config.php', $fp);
+            file_put_contents(self::path($directory, 'wp-config.php'), $fp);
             $logger->log(LogLevel::INFO, 'Configuration saved');
         } else {
             $logger->log(LogLevel::NOTICE, 'Skipping step due to missing database configuration');
@@ -46,12 +46,12 @@ class WordpressInstaller extends AbstractInstaller {
         }
 
         define('WP_INSTALLING', true);
-        require_once $directory.DIRECTORY_SEPARATOR.'wp-config.php';
-        // require_once $directory.DIRECTORY_SEPARATOR.'includes'.DIRECTORY_SEPARATOR.'wp-db.php';
-        require_once $directory.DIRECTORY_SEPARATOR.'wp-admin'.DIRECTORY_SEPARATOR.'upgrade-functions.php';
+        require_once self::path($directory, 'wp-config.php');
+        // require_once self::path($directory, 'includes', 'wp-db.php';
+        require_once self::path($directory, 'wp-admin', 'upgrade-functions.php');
 
         if (!function_exists('wp_install')) {
-            $logger->log(LogLevel::WARNING, 'Could not find function "wp_install" in file "'.$directory.DIRECTORY_SEPARATOR.'wp-admin'.DIRECTORY_SEPARATOR.'includes'.DIRECTORY_SEPARATOR.'upgrade.php"');
+            $logger->log(LogLevel::WARNING, 'Could not find function "wp_install" in file "'.self::path($directory, 'wp-admin', 'includes', 'upgrade.php"'));
         }
         if (isset($data['password'])) {
             $logger->log(LogLevel::INFO, 'Using password: '.$data['password']);


### PR DESCRIPTION
Adds method AbstractInstaller::path() to avoid DIRECTORY_SEPARATOR constant. Makes lines shorter.